### PR TITLE
Use generic dotenv loading

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -1,4 +1,3 @@
-# /Users/yer/Desktop/scrappaa/Domain_checker_ai/agents.py
 """
 Contains all AI Agent implementations for the Domain Generator.
 """

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-# /Users/yer/Desktop/scrappaa/Domain_checker_ai/main.py
 """
 Main entry point for the Domain Agent CLI application.
 """

--- a/model_checker.py
+++ b/model_checker.py
@@ -1,4 +1,3 @@
-# /Domain_checker_ai/model_checker.py
 """
 This module contains the function for checking domain availability using
 the OpenAI Responses API with the 'o4-mini' model and web_search tool.

--- a/search_checker.py
+++ b/search_checker.py
@@ -1,10 +1,10 @@
 # domain_status_combined.py
 import os, json, re
-from dotenv import load_dotenv
+from dotenv import load_dotenv, find_dotenv
 from openai import OpenAI
 
 # pick up API key
-load_dotenv("/Users/yer/Desktop/scrappaa/Domain_checker_ai/.env")
+load_dotenv(find_dotenv())
 client = OpenAI()
 
 def check_domains(domains):

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,3 @@
-# /Users/yer/Desktop/scrappaa/Domain_checker_ai/settings.py
 """
 Central configuration file for the Domain Agent system.
 This makes it easy to swap models, change temperatures, or adjust parameters

--- a/store.py
+++ b/store.py
@@ -1,4 +1,3 @@
-# /Domain_checker_ai/store.py
 """
 Session storage module. Handles the "memory" for each user session.
 """


### PR DESCRIPTION
## Summary
- update search_checker to use find_dotenv
- remove old absolute path comments
- ensure EOF newlines in several modules

## Testing
- `python search_checker.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68872dcc6e2c832a8a28fce7e7774bcb