### PR TITLE
Refactor API to multiple REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ This project exposes the domain generation logic via a FastAPI service.
 uvicorn api_server:app
 ```
 
-The service requires `DOMAIN_API_KEY` for all requests using the `X-API-Key` header.
+All requests must include `X-API-Key` set to the value of `DOMAIN_API_KEY`.
+
+## API Overview
+
+The service mirrors the interactive CLI in four small steps:
+
+1. **Start a session** – `POST /sessions` with `{ "initial_brief": "..." }`.
+   Returns the `session_id` and first clarification questions.
+2. **Submit answers** – `POST /sessions/{id}/answers` with the question/answer map.
+   Returns the synthesized prompt used for generation.
+3. **Generate suggestions** – `POST /sessions/{id}/generate`.
+   Returns lists of available and taken domains.
+4. **Provide feedback** – `POST /sessions/{id}/feedback` with liked domains and/or a dislike reason.
+   Returns the refined brief and the next set of questions.
+
+`GET /sessions/{id}/state` can be used for debugging or resuming a UI.
 
 ## Next.js Client
 

--- a/api_server.py
+++ b/api_server.py
@@ -1,12 +1,9 @@
 import logging
-import os
-from dotenv import load_dotenv
-
-from fastapi import FastAPI, HTTPException, Header, Depends
-from pydantic import BaseModel
 from typing import Dict, List, Optional
 
-load_dotenv()
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Header, Depends
+from pydantic import BaseModel
 
 import settings
 from store import SessionStore
@@ -18,6 +15,8 @@ from agents import (
     CheckerAgent,
     DirectionistAgent,
 )
+
+load_dotenv()
 
 app = FastAPI()
 
@@ -32,7 +31,8 @@ creator_agent = CreatorAgent()
 checker_agent = CheckerAgent()
 directionist_agent = DirectionistAgent()
 
-session_meta: Dict[str, dict] = {}
+# In-memory session cache
+session_state: Dict[str, Dict] = {}
 
 
 def verify_key(x_api_key: str = Header(...)):
@@ -40,79 +40,102 @@ def verify_key(x_api_key: str = Header(...)):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 
-class StartRequest(BaseModel):
-    brief: str
+class StartSessionIn(BaseModel):
+    initial_brief: str
 
 
-class StartResponse(BaseModel):
+class StartSessionOut(BaseModel):
     session_id: str
     questions: List[str]
 
 
-class AnswerRequest(BaseModel):
+class AnswerIn(BaseModel):
     answers: Dict[str, str]
-    liked_domains: Optional[Dict[str, str]] = None
+
+
+class PromptOut(BaseModel):
+    prompt: str
+
+
+class SuggestionsOut(BaseModel):
+    available: List[str]
+    taken: List[str]
+
+
+class FeedbackIn(BaseModel):
+    liked: Optional[Dict[str, str]] = None
     dislike_reason: Optional[str] = None
 
 
-class AnswerResponse(BaseModel):
-    available: Dict[str, str]
-    taken: Dict[str, str]
-    next_questions: List[str]
+class RefinementOut(BaseModel):
+    refined_brief: str
+    questions: List[str]
 
 
-@app.post("/session/start", response_model=StartResponse)
-def start(req: StartRequest, _=Depends(verify_key)):
+@app.post("/sessions", response_model=StartSessionOut)
+def start_session(payload: StartSessionIn, _=Depends(verify_key)):
     sid = store.new()
-    meta = {
-        "initial_brief": req.brief,
-        "current_brief": req.brief,
-        "last_feedback_summary": "",
-        "loop_count": 1,
-        "last_taken_domains": [],
+    questions = question_agent.ask(payload.initial_brief)
+    session_state[sid] = {
+        "brief": payload.initial_brief,
+        "loop": 1,
+        "questions": questions,
     }
-    questions = question_agent.ask(req.brief)
-    meta["last_questions"] = questions
-    session_meta[sid] = meta
-    return StartResponse(session_id=sid, questions=questions)
+    return {"session_id": sid, "questions": questions}
 
 
-@app.post("/session/{session_id}/answer", response_model=AnswerResponse)
-def answer(session_id: str, req: AnswerRequest, _=Depends(verify_key)):
-    if session_id not in session_meta:
+@app.post("/sessions/{sid}/answers", response_model=PromptOut)
+def submit_answers(sid: str, payload: AnswerIn, _=Depends(verify_key)):
+    state = session_state.get(sid)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session not found")
+    prompt = prompt_synthesizer.synthesize(state["brief"], payload.answers)
+    state["prompt"] = prompt
+    state["answers"] = payload.answers
+    return {"prompt": prompt}
+
+
+@app.post("/sessions/{sid}/generate", response_model=SuggestionsOut)
+async def generate_suggestions(sid: str, _=Depends(verify_key)):
+    state = session_state.get(sid)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if not state.get("prompt"):
+        raise HTTPException(status_code=400, detail="No prompt. Submit answers first")
+
+    ideas = creator_agent.create(state["prompt"], store.seen(sid))
+    store.add(sid, list(ideas.keys()))
+    available, taken = checker_agent.filter_available(ideas)
+    state["available"] = available
+    state["taken"] = taken
+    return {"available": list(available.keys()), "taken": list(taken.keys())}
+
+
+@app.post("/sessions/{sid}/feedback", response_model=RefinementOut)
+def give_feedback(sid: str, payload: FeedbackIn, _=Depends(verify_key)):
+    state = session_state.get(sid)
+    if not state:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    meta = session_meta[session_id]
-
-    # Refine brief using feedback from previous loop
-    liked = req.liked_domains or {}
-    dislike = req.dislike_reason
+    liked = payload.liked or {}
+    dislike = payload.dislike_reason
     new_brief, summary = directionist_agent.refine_brief(
-        meta["current_brief"], liked, meta["last_taken_domains"], dislike
+        state["brief"], liked, list(state.get("taken", {}).keys()), dislike
     )
-    meta["current_brief"] = new_brief
-    meta["last_feedback_summary"] = summary
-
-    final_prompt = prompt_synthesizer.synthesize(new_brief, req.answers)
-    ideas = creator_agent.create(final_prompt, store.seen(session_id))
-    store.add(session_id, list(ideas.keys()))
-
-    if ideas:
-        available, taken = checker_agent.filter_available(ideas)
-    else:
-        available, taken = {}, {}
-
-    if not available:
-        meta["failures"] = meta.get("failures", 0) + 1
-        if meta["failures"] >= settings.MAX_LOOP_FAILURES:
-            raise HTTPException(status_code=400, detail="Too many failures")
-    else:
-        meta["failures"] = 0
-
-    meta["last_taken_domains"] = list(taken.keys())
-    meta["loop_count"] += 1
-
+    state["brief"] = new_brief
+    state["loop"] = state.get("loop", 1) + 1
     questions = refinement_question_agent.ask(new_brief, summary)
-    meta["last_questions"] = questions
+    state["questions"] = questions
+    # Clear prompt and suggestions for next loop
+    state.pop("prompt", None)
+    state.pop("available", None)
+    state.pop("taken", None)
+    return {"refined_brief": new_brief, "questions": questions}
 
-    return AnswerResponse(available=available, taken=taken, next_questions=questions)
+
+@app.get("/sessions/{sid}/state")
+def get_state(sid: str, _=Depends(verify_key)):
+    state = session_state.get(sid)
+    if not state:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return state

--- a/nextjs/app/api/domain/route.ts
+++ b/nextjs/app/api/domain/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { startSession, answerSession } from '@/lib/domainClient';
+import {
+  startSession,
+  submitAnswers,
+  generateSuggestions,
+  sendFeedback,
+  getState,
+} from '@/lib/domainClient';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -7,10 +13,21 @@ export async function POST(req: NextRequest) {
     if (body.action === 'start') {
       return NextResponse.json(await startSession(body.brief));
     }
-    if (body.action === 'answer') {
+    if (body.action === 'answers') {
       return NextResponse.json(
-        await answerSession(body.sessionId, body.payload)
+        await submitAnswers(body.sessionId, body.payload)
       );
+    }
+    if (body.action === 'generate') {
+      return NextResponse.json(await generateSuggestions(body.sessionId));
+    }
+    if (body.action === 'feedback') {
+      return NextResponse.json(
+        await sendFeedback(body.sessionId, body.payload)
+      );
+    }
+    if (body.action === 'state') {
+      return NextResponse.json(await getState(body.sessionId));
     }
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
   } catch (err: any) {

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -3,32 +3,42 @@ export const DOMAIN_API_KEY = process.env.DOMAIN_API_KEY!;
 
 export interface AnswerPayload {
   answers: Record<string, string>;
-  liked_domains?: Record<string, string>;
+}
+
+export interface FeedbackPayload {
+  liked?: Record<string, string>;
   dislike_reason?: string;
 }
 
-export async function startSession(brief: string) {
-  const res = await fetch(`${DOMAIN_API_URL}/session/start`, {
-    method: 'POST',
+async function callApi(path: string, method: string, body?: any) {
+  const res = await fetch(`${DOMAIN_API_URL}${path}`, {
+    method,
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': DOMAIN_API_KEY,
     },
-    body: JSON.stringify({ brief }),
+    body: body ? JSON.stringify(body) : undefined,
   });
-  if (!res.ok) throw new Error('startSession failed');
+  if (!res.ok) throw new Error(`API ${path} failed`);
   return res.json();
 }
 
-export async function answerSession(sessionId: string, payload: AnswerPayload) {
-  const res = await fetch(`${DOMAIN_API_URL}/session/${sessionId}/answer`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-Key': DOMAIN_API_KEY,
-    },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) throw new Error('answerSession failed');
-  return res.json();
+export function startSession(initialBrief: string) {
+  return callApi('/sessions', 'POST', { initial_brief: initialBrief });
+}
+
+export function submitAnswers(sessionId: string, payload: AnswerPayload) {
+  return callApi(`/sessions/${sessionId}/answers`, 'POST', payload);
+}
+
+export function generateSuggestions(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/generate`, 'POST');
+}
+
+export function sendFeedback(sessionId: string, payload: FeedbackPayload) {
+  return callApi(`/sessions/${sessionId}/feedback`, 'POST', payload);
+}
+
+export function getState(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/state`, 'GET');
 }


### PR DESCRIPTION
## Summary
- expose session flow via new `/sessions` endpoints
- adjust Next.js client and proxy route for new API
- update README with endpoint usage

## Testing
- `python -m py_compile api_server.py agents.py main.py store.py settings.py model_checker.py search_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_68878dc4f43c832aaf968cb293ea130e