### PR TITLE
Refactor API to multiple REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ This project exposes the domain generation logic via a FastAPI service.
 uvicorn api_server:app
 ```
 
-The service requires `DOMAIN_API_KEY` for all requests using the `X-API-Key` header.
+All requests must include `X-API-Key` set to the value of `DOMAIN_API_KEY`.
+
+## API Overview
+
+The service mirrors the interactive CLI in four small steps:
+
+1. **Start a session** – `POST /sessions` with `{ "initial_brief": "..." }`.
+   Returns the `session_id` and first clarification questions.
+2. **Submit answers** – `POST /sessions/{id}/answers` with the question/answer map.
+   Returns the synthesized prompt used for generation.
+3. **Generate suggestions** – `POST /sessions/{id}/generate`.
+   Returns lists of available and taken domains.
+4. **Provide feedback** – `POST /sessions/{id}/feedback` with liked domains and/or a dislike reason.
+   Returns the refined brief and the next set of questions.
+
+`GET /sessions/{id}/state` can be used for debugging or resuming a UI.
 
 ## Next.js Client
 

--- a/agents.py
+++ b/agents.py
@@ -4,6 +4,8 @@ Contains all AI Agent implementations for the Domain Generator.
 from __future__ import annotations
 import os, json, time, re, logging
 from typing import List, Dict, Tuple, Optional
+from dotenv import load_dotenv
+load_dotenv()
 
 import google.generativeai as genai
 from openai import OpenAI

--- a/nextjs/app/api/domain/route.ts
+++ b/nextjs/app/api/domain/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { startSession, answerSession } from '@/lib/domainClient';
+import {
+  startSession,
+  submitAnswers,
+  generateSuggestions,
+  sendFeedback,
+  getState,
+} from '@/lib/domainClient';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();
@@ -7,10 +13,21 @@ export async function POST(req: NextRequest) {
     if (body.action === 'start') {
       return NextResponse.json(await startSession(body.brief));
     }
-    if (body.action === 'answer') {
+    if (body.action === 'answers') {
       return NextResponse.json(
-        await answerSession(body.sessionId, body.payload)
+        await submitAnswers(body.sessionId, body.payload)
       );
+    }
+    if (body.action === 'generate') {
+      return NextResponse.json(await generateSuggestions(body.sessionId));
+    }
+    if (body.action === 'feedback') {
+      return NextResponse.json(
+        await sendFeedback(body.sessionId, body.payload)
+      );
+    }
+    if (body.action === 'state') {
+      return NextResponse.json(await getState(body.sessionId));
     }
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
   } catch (err: any) {

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -3,32 +3,42 @@ export const DOMAIN_API_KEY = process.env.DOMAIN_API_KEY!;
 
 export interface AnswerPayload {
   answers: Record<string, string>;
-  liked_domains?: Record<string, string>;
+}
+
+export interface FeedbackPayload {
+  liked?: Record<string, string>;
   dislike_reason?: string;
 }
 
-export async function startSession(brief: string) {
-  const res = await fetch(`${DOMAIN_API_URL}/session/start`, {
-    method: 'POST',
+async function callApi(path: string, method: string, body?: any) {
+  const res = await fetch(`${DOMAIN_API_URL}${path}`, {
+    method,
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': DOMAIN_API_KEY,
     },
-    body: JSON.stringify({ brief }),
+    body: body ? JSON.stringify(body) : undefined,
   });
-  if (!res.ok) throw new Error('startSession failed');
+  if (!res.ok) throw new Error(`API ${path} failed`);
   return res.json();
 }
 
-export async function answerSession(sessionId: string, payload: AnswerPayload) {
-  const res = await fetch(`${DOMAIN_API_URL}/session/${sessionId}/answer`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-API-Key': DOMAIN_API_KEY,
-    },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) throw new Error('answerSession failed');
-  return res.json();
+export function startSession(initialBrief: string) {
+  return callApi('/sessions', 'POST', { initial_brief: initialBrief });
+}
+
+export function submitAnswers(sessionId: string, payload: AnswerPayload) {
+  return callApi(`/sessions/${sessionId}/answers`, 'POST', payload);
+}
+
+export function generateSuggestions(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/generate`, 'POST');
+}
+
+export function sendFeedback(sessionId: string, payload: FeedbackPayload) {
+  return callApi(`/sessions/${sessionId}/feedback`, 'POST', payload);
+}
+
+export function getState(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/state`, 'GET');
 }


### PR DESCRIPTION
## Summary
- expose session flow via new `/sessions` endpoints
- adjust Next.js client and proxy route for new API
- update README with endpoint usage
- fix env loading for server

## Testing
- `python -m py_compile api_server.py agents.py main.py store.py settings.py model_checker.py search_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_68878dc4f43c832aaf968cb293ea130e