### PR TITLE
Implement question ID workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ All requests must include `X-API-Key` set to the value of `DOMAIN_API_KEY`.
 The service mirrors the interactive CLI in four small steps:
 
 1. **Start a session** – `POST /sessions` with `{ "initial_brief": "..." }`.
-   Returns the `session_id` and first clarification questions.
-2. **Submit answers** – `POST /sessions/{id}/answers` with the question/answer map.
+   Returns the `session_id` and a list of question objects:
+   `[{"id": "q1", "text": "..."}, ...]`.
+2. **Submit answers** – `POST /sessions/{id}/answers` with answers keyed by question ID,
+   e.g. `{ "answers": {"q1": "yes"} }`.
    Returns the synthesized prompt used for generation.
 3. **Generate suggestions** – `POST /sessions/{id}/generate`.
    Returns lists of available and taken domains along with a history of all names checked in the session.
 4. **Provide feedback** – `POST /sessions/{id}/feedback` with liked domains and/or a dislike reason.
-   Returns the refined brief and the next set of questions.
+   Returns the refined brief and another list of question objects.
 
 `GET /sessions/{id}/state` returns the current loop info and the domain history for that session.
 
@@ -40,3 +42,4 @@ DOMAIN_API_KEY=<same key as server>
 ```
 
 Use the helpers in `nextjs/lib/domainClient.ts` to interact with the API.
+Questions are returned with stable `id` fields; use these IDs when sending answer payloads.

--- a/main.py
+++ b/main.py
@@ -67,10 +67,11 @@ def run_session():
             print(f"Loop #{loop_count} | Refined Brief: \"{current_brief[:100]}...\"")
             questions = refinement_question_agent.ask(current_brief, last_feedback_summary)
         
+        question_map = {q['id']: q['text'] for q in questions}
         for q in questions:
-            q_and_a[q] = input(f"❓ {q} ") or "no comment"
+            q_and_a[q['id']] = input(f"❓ {q['text']} ") or "no comment"
 
-        final_prompt = prompt_synthesizer.synthesize(current_brief, q_and_a)
+        final_prompt = prompt_synthesizer.synthesize(current_brief, q_and_a, question_map)
         
         # --- Simplified Single-Pass Generation ---
         log.info("Generating a new batch of domain ideas based on your settings...")

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -5,6 +5,11 @@ export interface AnswerPayload {
   answers: Record<string, string>;
 }
 
+export interface Question {
+  id: string;
+  text: string;
+}
+
 export interface FeedbackPayload {
   liked?: Record<string, string>;
   dislike_reason?: string;


### PR DESCRIPTION
## Summary
- return question objects with IDs from QuestionAgent and RefinementQuestionAgent
- track `question_map` in session state and store
- update PromptSynthesizerAgent to rebuild Q/A pairs from IDs
- adjust FastAPI models and handlers for ID‐based questions
- tweak CLI and Next.js client accordingly
- document new question format in README

## Testing
- `python -m py_compile api_server.py agents.py store.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6887bafd0584832ab9f23b584ede5ef2