### PR TITLE
Implement per-domain feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ All requests must include `X-API-Key` set to the value of `DOMAIN_API_KEY`.
 The service mirrors the interactive CLI in four small steps:
 
 1. **Start a session** – `POST /sessions` with `{ "initial_brief": "..." }`.
-   Returns the `session_id` and first clarification questions.
-2. **Submit answers** – `POST /sessions/{id}/answers` with the question/answer map.
+   Returns the `session_id` and a list of question objects:
+   `[{"id": "q1", "text": "..."}, ...]`.
+2. **Submit answers** – `POST /sessions/{id}/answers` with answers keyed by question ID,
+   e.g. `{ "answers": {"q1": "yes"} }`.
    Returns the synthesized prompt used for generation.
 3. **Generate suggestions** – `POST /sessions/{id}/generate`.
    Returns lists of available and taken domains along with a history of all names checked in the session.
-4. **Provide feedback** – `POST /sessions/{id}/feedback` with liked domains and/or a dislike reason.
-   Returns the refined brief and the next set of questions.
+4. **Provide feedback** – `POST /sessions/{id}/feedback` with optional `liked` and `disliked` maps.
+   Each is a mapping of domain → reason. Returns the refined brief and another list of question objects.
 
 `GET /sessions/{id}/state` returns the current loop info and the domain history for that session.
 
@@ -40,3 +42,4 @@ DOMAIN_API_KEY=<same key as server>
 ```
 
 Use the helpers in `nextjs/lib/domainClient.ts` to interact with the API.
+Questions are returned with stable `id` fields; use these IDs when sending answer payloads.

--- a/agents.py
+++ b/agents.py
@@ -32,19 +32,24 @@ class QuestionAgent:
         self.generation_config = genai.types.GenerationConfig(temperature=cfg["temperature"])
         self.system_prompt = "# ROLE\nYou are a clarifier. Your only task is to ask follow-up questions that will let a\nlater agent generate the best possible domain names.\n\n# RULES\n• Output valid JSON only.\n• Keys must be \"q1\", \"q2\", … in order.\n• No markdown fences or prose.\n• Ask 2–10 questions – the fewest that fully clarify the brief.\n\n# GUIDELINES  (topics you may cover)\n• Brand / company match                • Desired TLD(s)\n• Tone or vibe                         • Length limits\n• Keywords to include / avoid          • Real-word vs. abstract\n• Examples the user likes (but are taken)\n• Legal / geographic constraints"
 
-    def ask(self, brief: str) -> List[str]:
+    def ask(self, brief: str) -> List[Dict[str, str]]:
         prompt = f"{self.system_prompt}\n\nUSER'S INITIAL BRIEF: \"{brief}\""
         log.debug("--- START QuestionAgent PROMPT ---\n%s\n--- END QuestionAgent PROMPT ---", prompt)
         try:
             response = self.model.generate_content(prompt, generation_config=self.generation_config)
             log.debug("--- START QuestionAgent RAW RESPONSE ---\n%s\n--- END QuestionAgent RAW RESPONSE ---", response.text)
             data = json.loads(_clean_json_response(response.text))
-            questions = [data[key] for key in sorted(data.keys())]
+            questions = [
+                {"id": key, "text": data[key]} for key in sorted(data.keys())
+            ]
             log.info(f"Generated {len(questions)} initial questions.")
             return questions
         except Exception as e:
             log.warning(f"QuestionAgent failed: {e}. Falling back.")
-            return ["Primary purpose?", "Target audience?"]
+            return [
+                {"id": "q1", "text": "Primary purpose?"},
+                {"id": "q2", "text": "Target audience?"},
+            ]
 
 class PromptSynthesizerAgent:
     """Takes a brief and Q&A and synthesizes a high-quality narrative prompt."""
@@ -54,13 +59,22 @@ class PromptSynthesizerAgent:
         self.system_prompt = "You are a master prompt engineer. Your task is to synthesize a user's brief and a set of questions and answers into a single, cohesive, and well-written narrative brief. This new brief will be given to a creative AI to generate domain names. Transform the raw Q&A into a descriptive paragraph. Infer the user's core desires from their answers. Only use the information provided; do not add new details."
         self.ignore_answers = {'no', 'none', 'n/a', '', 'no comment'}
 
-    def synthesize(self, brief: str, q_and_a: Dict[str, str]) -> str:
-        filtered_qa = {q: a for q, a in q_and_a.items() if a.lower().strip() not in self.ignore_answers}
-        if not filtered_qa:
+    def synthesize(self, brief: str, answers: Dict[str, str], question_map: Dict[str, str]) -> str:
+        ordered_ids = sorted(question_map.keys(), key=lambda k: int(k[1:]))
+        pairs = []
+        for qid in ordered_ids:
+            answer = answers.get(qid, "").strip()
+            if answer.lower() in self.ignore_answers:
+                continue
+            question_text = question_map.get(qid)
+            if question_text:
+                pairs.append((question_text, answer))
+
+        if not pairs:
             log.info("No meaningful answers provided, using initial brief only.")
             return brief
 
-        qa_text = "\n".join([f"Q: {q}\nA: {a}" for q, a in filtered_qa.items()])
+        qa_text = "\n".join([f"Q: {q}\nA: {a}" for q, a in pairs])
         prompt = f"{self.system_prompt}\n\n# CORE BRIEF:\n{brief}\n\n# USER'S ANSWERS:\n{qa_text}\n\nSynthesize this into a paragraph."
         log.debug("--- START PromptSynthesizerAgent PROMPT ---\n%s\n--- END PromptSynthesizerAgent PROMPT ---", prompt)
         try:
@@ -249,19 +263,25 @@ class RefinementQuestionAgent:
         self.model = genai.GenerativeModel(cfg["model"])
         self.generation_config = genai.types.GenerationConfig(temperature=cfg["temperature"])
         self.system_prompt = "# ROLE\nYou are a domain name strategy consultant..."
-    def ask(self, refined_brief: str, feedback_summary: str) -> List[str]:
+    def ask(self, refined_brief: str, feedback_summary: str) -> List[Dict[str, str]]:
         prompt = (f"{self.system_prompt}\n\n# PREVIOUS FEEDBACK SUMMARY\n{feedback_summary}\n\n# NEW REFINED GOAL\n\"{refined_brief}\"\n\nBased on all the above, ask your two follow-up questions now.")
         log.debug("--- START RefinementQuestionAgent PROMPT ---\n%s\n--- END RefinementQuestionAgent PROMPT ---", prompt)
         try:
             response = self.model.generate_content(prompt, generation_config=self.generation_config)
             log.debug("--- START RefinementQuestionAgent RAW RESPONSE ---\n%s\n--- END RefinementQuestionAgent RAW RESPONSE ---", response.text)
             data = json.loads(_clean_json_response(response.text))
-            questions = [data["q1"], data["q2"]]
+            questions = [
+                {"id": "q1", "text": data["q1"]},
+                {"id": "q2", "text": data["q2"]},
+            ]
             log.info(f"Generated {len(questions)} refinement questions.")
             return questions
         except Exception as e:
             log.warning(f"RefinementQuestionAgent failed: {e}. Falling back.")
-            return ["What specific element did you like most?", "What was missing?"]
+            return [
+                {"id": "q1", "text": "What specific element did you like most?"},
+                {"id": "q2", "text": "What was missing?"},
+            ]
 
 class DirectionistAgent:
     """Refines the brief using all feedback."""
@@ -269,14 +289,41 @@ class DirectionistAgent:
         self.config = settings.DIRECTIONIST_AGENT_CONFIG
         self.model = self.config["model"]
         self.system_prompt = "You are a prompt optimizer..."
-    def _build_feedback_summary(self, liked_domains: Dict[str, str], taken_domains: List[str], dislike_reason: Optional[str]) -> str:
+    def _build_feedback_summary(
+        self,
+        liked_domains: Dict[str, str],
+        taken_domains: List[str],
+        disliked_domains: Dict[str, str],
+    ) -> str:
         parts = []
-        if liked_domains: parts.append(f"POSITIVE FEEDBACK (domains the user liked):\n" + "\n".join([f"- Liked '{d}': {r}" for d, r in liked_domains.items()]))
-        if taken_domains: parts.append(f"NEGATIVE FEEDBACK (these were good ideas, but already taken):\n- {', '.join(taken_domains)}")
-        if dislike_reason: parts.append(f"CRITICAL FEEDBACK (why the user disliked all previous suggestions):\n- {dislike_reason}")
+        if liked_domains:
+            parts.append(
+                "POSITIVE FEEDBACK (domains the user liked):\n"
+                + "\n".join([f"- Liked '{d}': {r}" for d, r in liked_domains.items()])
+            )
+        if disliked_domains:
+            parts.append(
+                "NEGATIVE FEEDBACK (domains the user disliked):\n"
+                + "\n".join([f"- Disliked '{d}': {r}" for d, r in disliked_domains.items()])
+            )
+        if taken_domains:
+            parts.append(
+                "NEGATIVE FEEDBACK (these were good ideas, but already taken):\n- "
+                + ", ".join(taken_domains)
+            )
         return "\n\n".join(parts)
-    def refine_brief(self, original_brief: str, liked_domains: Dict[str, str], taken_domains: List[str], dislike_reason: Optional[str] = None) -> Tuple[str, str]:
-        feedback_summary = self._build_feedback_summary(liked_domains, taken_domains, dislike_reason)
+
+    def refine_brief(
+        self,
+        original_brief: str,
+        liked_domains: Dict[str, str],
+        taken_domains: List[str],
+        disliked_domains: Optional[Dict[str, str]] = None,
+    ) -> Tuple[str, str]:
+        disliked_domains = disliked_domains or {}
+        feedback_summary = self._build_feedback_summary(
+            liked_domains, taken_domains, disliked_domains
+        )
         if not feedback_summary: return original_brief, ""
         prompt = (f"{self.system_prompt}\n\nORIGINAL BRIEF:\n{original_brief}\n\nUSER FEEDBACK ANALYSIS:\n{feedback_summary}\n\nGenerate the new, refined brief now.")
         log.debug("--- START DirectionistAgent PROMPT ---\n%s\n--- END DirectionistAgent PROMPT ---", prompt)

--- a/api_server.py
+++ b/api_server.py
@@ -44,13 +44,24 @@ class StartSessionIn(BaseModel):
     initial_brief: str
 
 
+class Question(BaseModel):
+    id: str
+    text: str
+
 class StartSessionOut(BaseModel):
     session_id: str
-    questions: List[str]
+    questions: List[Question]
 
 
 class AnswerIn(BaseModel):
     answers: Dict[str, str]
+    liked_domains: Optional[Dict[str, str]] = None
+    disliked_domains: Optional[Dict[str, str]] = None
+
+class AnswerOut(BaseModel):
+    available: Dict[str, str]
+    taken: Dict[str, str]
+    next_questions: Optional[List[Question]] = None
 
 
 class PromptOut(BaseModel):
@@ -65,23 +76,25 @@ class SuggestionsOut(BaseModel):
 
 class FeedbackIn(BaseModel):
     liked: Optional[Dict[str, str]] = None
-    dislike_reason: Optional[str] = None
+    disliked: Optional[Dict[str, str]] = None
 
 
 class RefinementOut(BaseModel):
     refined_brief: str
-    questions: List[str]
+    questions: List[Question]
 
 
 @app.post("/sessions", response_model=StartSessionOut)
 def start_session(payload: StartSessionIn, _=Depends(verify_key)):
     sid = store.new()
     questions = question_agent.ask(payload.initial_brief)
+    qmap = {q["id"]: q["text"] for q in questions}
     session_state[sid] = {
         "brief": payload.initial_brief,
         "loop": 1,
-        "questions": questions,
+        "question_map": qmap,
     }
+    store.set_question_map(sid, qmap)
     return {"session_id": sid, "questions": questions}
 
 
@@ -90,7 +103,8 @@ def submit_answers(sid: str, payload: AnswerIn, _=Depends(verify_key)):
     state = session_state.get(sid)
     if not state:
         raise HTTPException(status_code=404, detail="Session not found")
-    prompt = prompt_synthesizer.synthesize(state["brief"], payload.answers)
+    qmap = state.get("question_map", {})
+    prompt = prompt_synthesizer.synthesize(state["brief"], payload.answers, qmap)
     state["prompt"] = prompt
     state["answers"] = payload.answers
     return {"prompt": prompt}
@@ -124,14 +138,16 @@ def give_feedback(sid: str, payload: FeedbackIn, _=Depends(verify_key)):
         raise HTTPException(status_code=404, detail="Session not found")
 
     liked = payload.liked or {}
-    dislike = payload.dislike_reason
+    disliked = payload.disliked or {}
     new_brief, summary = directionist_agent.refine_brief(
-        state["brief"], liked, list(state.get("taken", {}).keys()), dislike
+        state["brief"], liked, list(state.get("taken", {}).keys()), disliked
     )
     state["brief"] = new_brief
     state["loop"] = state.get("loop", 1) + 1
     questions = refinement_question_agent.ask(new_brief, summary)
-    state["questions"] = questions
+    qmap = {q["id"]: q["text"] for q in questions}
+    state["question_map"] = qmap
+    store.set_question_map(sid, qmap)
     # Clear prompt and suggestions for next loop
     state.pop("prompt", None)
     state.pop("available", None)

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -5,9 +5,14 @@ export interface AnswerPayload {
   answers: Record<string, string>;
 }
 
+export interface Question {
+  id: string;
+  text: string;
+}
+
 export interface FeedbackPayload {
   liked?: Record<string, string>;
-  dislike_reason?: string;
+  disliked?: Record<string, string>;
 }
 
 async function callApi(path: string, method: string, body?: any) {


### PR DESCRIPTION
## Summary
- support disliked domain reasons via dicts in API
- refine DirectionistAgent to use per-domain likes/dislikes
- adjust CLI prompts for individual liked/disliked domains
- update Next.js client interface
- clarify feedback route docs

## Testing
- `python -m py_compile api_server.py agents.py store.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6887bafd0584832ab9f23b584ede5ef2