### PR TITLE
Add clarifying and feedback combine agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ The service mirrors the interactive CLI in four small steps:
 
 `GET /sessions/{id}/state` returns the current loop info and the domain history for that session.
 
+Additional helpers:
+
+- `POST /clarify` with `{ "prompt": "..." }` returns two clarifying
+  questions.
+- `POST /combine` combines the previous prompt and user feedback
+  into a new prompt. The payload is `{ "previous_prompt": "...",
+  "answers": {...}, "question_map": {...}, "liked_domains": {...},
+  "disliked_domains": {...}, "taken_domains": ["..."] }` and the
+  response contains the refined `prompt`.
+
 ## Next.js Client
 
 The `nextjs/` directory contains a minimal client example. Configure


### PR DESCRIPTION
## Summary
- create `ClarifyingAgent` to ask exactly two questions
- create `FeedbackCombinerAgent` to merge prior prompt, feedback and Q&A
- expose new `/clarify` and `/combine` endpoints in the API server
- document endpoints in `README`

## Testing
- `python -m py_compile agents.py api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68886c2a332c832abadae2a328b1c5b5