### PR TITLE
Improve domain search loop and add logging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ uvicorn api_server:app
 
 All requests must include `X-API-Key` set to the value of `DOMAIN_API_KEY`.
 
+### Environment Variables
+
+Several optional variables control the behaviour of generation:
+
+- `MIN_AVAILABLE_DOMAINS` – how many free domains the API should try to find per request (default `3`).
+- `MAX_GENERATION_ATTEMPTS` – safety cap on how many batches are generated while searching for free domains.
+- `SHOW_LOGS` – when set to `0`, the interactive client hides verbose output such as prompts and taken domains.
+
 ## API Overview
 
 The service mirrors the interactive CLI in four small steps:

--- a/settings.py
+++ b/settings.py
@@ -71,3 +71,18 @@ MAX_LOOP_FAILURES = 20 # The number of consecutive loops with no available domai
 PERSIST_SESSIONS_TO_FILE = True
 SESSION_FILE_DIR = "sessions"
 LOGS_DIR = "logs"
+
+# --- Domain Generation Goals ---
+# How many available domains the checker should aim to find in one generate
+# request. The API will loop locally until this many free domains are
+# discovered or until MAX_GENERATION_ATTEMPTS is reached.
+MIN_AVAILABLE_DOMAINS = int(os.getenv("MIN_AVAILABLE_DOMAINS", "3"))
+
+# Safety cap on how many batches will be generated/checked per request.
+MAX_GENERATION_ATTEMPTS = int(os.getenv("MAX_GENERATION_ATTEMPTS", "5"))
+
+# --- Client Display Options ---
+# When False, the interactive client will suppress verbose logs such as the
+# prompt, taken domains and refined briefs.  This is useful for a more
+# streamlined user experience.
+SHOW_LOGS = os.getenv("SHOW_LOGS", "1") != "0"


### PR DESCRIPTION
## Summary
- repeat generation attempts until a minimum number of free domains are found
- store taken domains and log them during generation
- allow hiding verbose logs via `SHOW_LOGS`
- update interactive client to new flow with continue prompt and per-domain feedback
- document new configuration options

## Testing
- `python -m py_compile interactive_client.py api_server.py settings.py agents.py store.py`

------
https://chatgpt.com/codex/tasks/task_e_68887b731bc4832a9e515183288c56fe