### PR TITLE
Simplify refinement flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,17 @@ The service mirrors the interactive CLI in four small steps:
    Returns the `session_id` and a list of question objects:
    `[{"id": "q1", "text": "..."}, ...]`.
 2. **Submit answers** – `POST /sessions/{id}/answers` with answers keyed by question ID,
-   e.g. `{ "answers": {"q1": "yes"} }`.
-   Returns the synthesized prompt used for generation.
+ e.g. `{ "answers": {"q1": "yes"} }`.
+  Returns the synthesized prompt used for generation.
 3. **Generate suggestions** – `POST /sessions/{id}/generate`.
    Returns lists of available and taken domains along with a history of all names checked in the session.
 4. **Provide feedback** – `POST /sessions/{id}/feedback` with optional `liked` and `disliked` maps.
-   Each is a mapping of domain → reason. Returns the refined brief and another list of question objects.
+   Each is a mapping of domain → reason. Returns the refined brief and a new
+   list of follow-up questions.
+   Answer these questions using step 2 before generating the next batch.
 
 `GET /sessions/{id}/state` returns the current loop info and the domain history for that session.
 
-Additional helpers:
-
-- `POST /clarify` with `{ "prompt": "..." }` returns two clarifying
-  questions.
-- `POST /combine` combines the previous prompt and user feedback
-  into a new prompt. The payload is `{ "previous_prompt": "...",
-  "answers": {...}, "question_map": {...}, "liked_domains": {...},
-  "disliked_domains": {...}, "taken_domains": ["..."] }` and the
-  response contains the refined `prompt`.
 
 ## Next.js Client
 

--- a/api_endpoint_tester.py
+++ b/api_endpoint_tester.py
@@ -1,0 +1,41 @@
+import os
+import requests
+
+API_URL = os.getenv("DOMAIN_API_URL", "http://localhost:8000")
+API_KEY = os.getenv("DOMAIN_API_KEY")
+HEADERS = {"X-API-Key": API_KEY} if API_KEY else {}
+
+
+def post(path: str, payload=None):
+    resp = requests.post(f"{API_URL}{path}", json=payload, headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def run_test_flow(initial_brief: str, answer_map: dict):
+    data = post("/sessions", {"initial_brief": initial_brief})
+    sid = data["session_id"]
+    questions = data["questions"]
+
+    # Answer initial questions
+    answers = {q["id"]: answer_map.get(q["id"], "") for q in questions}
+    prompt = post(f"/sessions/{sid}/answers", {"answers": answers})["prompt"]
+
+    # Generate once
+    suggestions = post(f"/sessions/{sid}/generate")
+
+    # Provide empty feedback just for demonstration
+    fb = post(f"/sessions/{sid}/feedback", {"liked": {}, "disliked": {}})
+    follow_up = {q["id"]: answer_map.get(q["id"], "") for q in fb["questions"]}
+    post(f"/sessions/{sid}/answers", {"answers": follow_up})
+
+    return {
+        "prompt": prompt,
+        "available": suggestions["available"],
+        "taken": suggestions["taken"],
+    }
+
+
+if __name__ == "__main__":
+    result = run_test_flow("demo business", {})
+    print(result)

--- a/api_server.py
+++ b/api_server.py
@@ -13,10 +13,8 @@ import settings
 from store import SessionStore
 from agents import (
     QuestionAgent,
-    ClarifyingAgent,
     RefinementQuestionAgent,
     PromptSynthesizerAgent,
-    FeedbackCombinerAgent,
     CreatorAgent,
     CheckerAgent,
     DirectionistAgent,
@@ -29,10 +27,8 @@ API_KEY = settings.API_KEY
 store = SessionStore()
 
 question_agent = QuestionAgent()
-clarifying_agent = ClarifyingAgent()
 refinement_question_agent = RefinementQuestionAgent()
 prompt_synthesizer = PromptSynthesizerAgent()
-feedback_combiner = FeedbackCombinerAgent()
 creator_agent = CreatorAgent()
 checker_agent = CheckerAgent()
 directionist_agent = DirectionistAgent()
@@ -90,25 +86,6 @@ class RefinementOut(BaseModel):
     questions: List[Question]
 
 
-class ClarifyIn(BaseModel):
-    prompt: str
-
-
-class ClarifyOut(BaseModel):
-    questions: List[Question]
-
-
-class CombineIn(BaseModel):
-    previous_prompt: str
-    answers: Dict[str, str]
-    question_map: Dict[str, str]
-    liked_domains: Optional[Dict[str, str]] = None
-    disliked_domains: Optional[Dict[str, str]] = None
-    taken_domains: Optional[List[str]] = None
-
-
-class CombineOut(BaseModel):
-    prompt: str
 
 
 @app.post("/sessions", response_model=StartSessionOut)
@@ -206,20 +183,3 @@ def get_state(sid: str, _=Depends(verify_key)):
     return state_copy
 
 
-@app.post("/clarify", response_model=ClarifyOut)
-def clarify(payload: ClarifyIn, _=Depends(verify_key)):
-    questions = clarifying_agent.ask(payload.prompt)
-    return {"questions": questions}
-
-
-@app.post("/combine", response_model=CombineOut)
-def combine(payload: CombineIn, _=Depends(verify_key)):
-    prompt = feedback_combiner.combine(
-        payload.previous_prompt,
-        payload.answers,
-        payload.question_map,
-        payload.liked_domains,
-        payload.taken_domains,
-        payload.disliked_domains,
-    )
-    return {"prompt": prompt}

--- a/interactive_client.py
+++ b/interactive_client.py
@@ -68,23 +68,6 @@ def main():
             print("\nRefined Brief:\n" + fb["refined_brief"])
         questions = fb["questions"]
 
-        clar = post("/clarify", {"prompt": prompt})
-        clar_answers = ask_questions(clar["questions"])
-        new_prompt = post(
-            "/combine",
-            {
-                "previous_prompt": prompt,
-                "answers": clar_answers,
-                "question_map": {q["id"]: q["text"] for q in clar["questions"]},
-                "liked_domains": liked,
-                "disliked_domains": disliked,
-                "taken_domains": gen["taken"],
-            },
-        )["prompt"]
-        prompt = new_prompt
-        if SHOW_LOGS:
-            print("\nNew Prompt:\n" + prompt)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- drop extra clarification step after feedback
- remove `/clarify` and `/combine` endpoints
- update README
- streamline interactive client
- add a small API testing helper script

## Testing
- `python -m py_compile api_server.py interactive_client.py api_endpoint_tester.py`

------
https://chatgpt.com/codex/tasks/task_e_688882793b24832abab559f72db1126b