### PR TITLE
Add per-session configuration endpoint

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -143,12 +143,16 @@ class CreatorAgent:
             log.error(f"CreatorAgent ({tag}) failed: {e}")
             return {}
             
-    def create(self, prompt: str, previously_seen: set) -> Dict[str, str]:
-        # This method no longer splits a passed-in count.
-        # It reads the generation count for each creator directly from its configuration.
-        count_a = settings.CREATOR_A_CONFIG.get("generation_count", 0)
-        count_b = settings.CREATOR_B_CONFIG.get("generation_count", 0)
-        count_c = settings.CREATOR_C_CONFIG.get("generation_count", 0)
+    def create(self, prompt: str, previously_seen: set, counts: Optional[Dict[str, int]] = None) -> Dict[str, str]:
+        # Determine how many ideas each creator should generate for this call.
+        if counts is None:
+            count_a = settings.CREATOR_A_CONFIG.get("generation_count", 0)
+            count_b = settings.CREATOR_B_CONFIG.get("generation_count", 0)
+            count_c = settings.CREATOR_C_CONFIG.get("generation_count", 0)
+        else:
+            count_a = counts.get("A", 0)
+            count_b = counts.get("B", 0)
+            count_c = counts.get("C", 0)
 
         ideas_a = self._generate_batch(prompt, settings.CREATOR_A_CONFIG, "CreatorA", count_a)
         ideas_b = self._generate_batch(prompt, settings.CREATOR_B_CONFIG, "CreatorB", count_b)

--- a/api_endpoint_tester.py
+++ b/api_endpoint_tester.py
@@ -12,9 +12,10 @@ def post(path: str, payload=None):
     return resp.json()
 
 
-def run_test_flow(initial_brief: str, answer_map: dict):
+def run_test_flow(initial_brief: str, answer_map: dict, session_settings: dict):
     data = post("/sessions", {"initial_brief": initial_brief})
     sid = data["session_id"]
+    post(f"/sessions/{sid}/settings", session_settings)
     questions = data["questions"]
 
     # Answer initial questions
@@ -36,6 +37,24 @@ def run_test_flow(initial_brief: str, answer_map: dict):
     }
 
 
+def prompt_for_settings() -> dict:
+    local_dev = input("Use local dev mode? (y/N) ").strip().lower() == "y"
+    creators = input("Creators to use [A,B,C]: ").strip().upper()
+    active = [c.strip() for c in creators.split(',') if c.strip()] or ["A", "B", "C"]
+    gen_count = int(input("Generation count per creator [1]: ") or "1")
+    domain_goal = int(input("Desired available domains [3]: ") or "3")
+    show_logs = input("Show logs? (y/N) ").strip().lower() == "y"
+    return {
+        "local_dev": local_dev,
+        "active_creators": active,
+        "generation_count": gen_count,
+        "domain_goal": domain_goal,
+        "show_logs": show_logs,
+    }
+
+
 if __name__ == "__main__":
-    result = run_test_flow("demo business", {})
+    cfg = prompt_for_settings()
+    brief = input("Describe the business or project: ")
+    result = run_test_flow(brief, {}, cfg)
     print(result)


### PR DESCRIPTION
## Summary
- allow client to set session-specific domain generation settings
- update generator to respect active creators and counts
- extend CreatorAgent with custom counts
- update API test helper to configure settings interactively

## Testing
- `python -m py_compile api_server.py agents.py api_endpoint_tester.py`

------
https://chatgpt.com/codex/tasks/task_e_68889061792c832ab6107a981b9512a3