### PR TITLE
Add per-session configuration endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,23 @@ Several optional variables control the behaviour of generation:
 
 ## API Overview
 
-The service mirrors the interactive CLI in four small steps:
+The service mirrors the interactive CLI in a few small steps:
 
 1. **Start a session** – `POST /sessions` with `{ "initial_brief": "..." }`.
    Returns the `session_id` and a list of question objects:
    `[{"id": "q1", "text": "..."}, ...]`.
-2. **Submit answers** – `POST /sessions/{id}/answers` with answers keyed by question ID,
- e.g. `{ "answers": {"q1": "yes"} }`.
-  Returns the synthesized prompt used for generation.
-3. **Generate suggestions** – `POST /sessions/{id}/generate`.
+2. **(Optional) Configure settings** – `POST /sessions/{id}/settings` to override
+   defaults like which creators are active, how many ideas each should generate,
+   the desired number of available domains and whether logs should be shown.
+3. **Submit answers** – `POST /sessions/{id}/answers` with answers keyed by question ID,
+   e.g. `{ "answers": {"q1": "yes"} }`.
+   Returns the synthesized prompt used for generation.
+4. **Generate suggestions** – `POST /sessions/{id}/generate`.
    Returns lists of available and taken domains along with a history of all names checked in the session.
-4. **Provide feedback** – `POST /sessions/{id}/feedback` with optional `liked` and `disliked` maps.
+5. **Provide feedback** – `POST /sessions/{id}/feedback` with optional `liked` and `disliked` maps.
    Each is a mapping of domain → reason. Returns the refined brief and a new
    list of follow-up questions.
-   Answer these questions using step 2 before generating the next batch.
+   Answer these questions using step 3 before generating the next batch.
 
 `GET /sessions/{id}/state` returns the current loop info and the domain history for that session.
 

--- a/agents.py
+++ b/agents.py
@@ -143,12 +143,16 @@ class CreatorAgent:
             log.error(f"CreatorAgent ({tag}) failed: {e}")
             return {}
             
-    def create(self, prompt: str, previously_seen: set) -> Dict[str, str]:
-        # This method no longer splits a passed-in count.
-        # It reads the generation count for each creator directly from its configuration.
-        count_a = settings.CREATOR_A_CONFIG.get("generation_count", 0)
-        count_b = settings.CREATOR_B_CONFIG.get("generation_count", 0)
-        count_c = settings.CREATOR_C_CONFIG.get("generation_count", 0)
+    def create(self, prompt: str, previously_seen: set, counts: Optional[Dict[str, int]] = None) -> Dict[str, str]:
+        # Determine how many ideas each creator should generate for this call.
+        if counts is None:
+            count_a = settings.CREATOR_A_CONFIG.get("generation_count", 0)
+            count_b = settings.CREATOR_B_CONFIG.get("generation_count", 0)
+            count_c = settings.CREATOR_C_CONFIG.get("generation_count", 0)
+        else:
+            count_a = counts.get("A", 0)
+            count_b = counts.get("B", 0)
+            count_c = counts.get("C", 0)
 
         ideas_a = self._generate_batch(prompt, settings.CREATOR_A_CONFIG, "CreatorA", count_a)
         ideas_b = self._generate_batch(prompt, settings.CREATOR_B_CONFIG, "CreatorB", count_b)

--- a/api_endpoint_tester.py
+++ b/api_endpoint_tester.py
@@ -12,30 +12,73 @@ def post(path: str, payload=None):
     return resp.json()
 
 
-def run_test_flow(initial_brief: str, answer_map: dict):
+def ask_questions(questions):
+    answers = {}
+    for q in questions:
+        ans = input(f"{q['text']} ") or ""
+        answers[q['id']] = ans
+    return answers
+
+
+def run_test_flow(initial_brief: str, session_settings: dict):
     data = post("/sessions", {"initial_brief": initial_brief})
     sid = data["session_id"]
+    post(f"/sessions/{sid}/settings", session_settings)
     questions = data["questions"]
+    show_logs = session_settings.get("show_logs", True)
 
-    # Answer initial questions
-    answers = {q["id"]: answer_map.get(q["id"], "") for q in questions}
-    prompt = post(f"/sessions/{sid}/answers", {"answers": answers})["prompt"]
+    while True:
+        answers = ask_questions(questions)
+        prompt = post(f"/sessions/{sid}/answers", {"answers": answers})["prompt"]
+        if show_logs:
+            print("\nPrompt:\n" + prompt)
 
-    # Generate once
-    suggestions = post(f"/sessions/{sid}/generate")
+        gen = post(f"/sessions/{sid}/generate")
+        print("\nAvailable:")
+        for d in gen["available"]:
+            print(" -", d)
+        if show_logs:
+            print("Taken:")
+            for d in gen["taken"]:
+                print(" -", d)
 
-    # Provide empty feedback just for demonstration
-    fb = post(f"/sessions/{sid}/feedback", {"liked": {}, "disliked": {}})
-    follow_up = {q["id"]: answer_map.get(q["id"], "") for q in fb["questions"]}
-    post(f"/sessions/{sid}/answers", {"answers": follow_up})
+        cont = input("Continue? (y/N) ").strip().lower()
+        if cont != "y":
+            break
 
+        liked, disliked = {}, {}
+        for d in gen["available"]:
+            like = input(f"Do you like '{d}'? (y/N) ").strip().lower()
+            reason = input("  Reason? ") or ""
+            if like == "y":
+                liked[d] = reason
+            else:
+                disliked[d] = reason
+
+        fb = post(f"/sessions/{sid}/feedback", {"liked": liked, "disliked": disliked})
+        if show_logs:
+            print("\nRefined Brief:\n" + fb["refined_brief"])
+        questions = fb["questions"]
+
+
+
+def prompt_for_settings() -> dict:
+    local_dev = input("Use local dev mode? (y/N) ").strip().lower() == "y"
+    creators = input("Creators to use [A,B,C]: ").strip().upper()
+    active = [c.strip() for c in creators.split(',') if c.strip()] or ["A", "B", "C"]
+    gen_count = int(input("Generation count per creator [1]: ") or "1")
+    domain_goal = int(input("Desired available domains [3]: ") or "3")
+    show_logs = input("Show logs? (y/N) ").strip().lower() == "y"
     return {
-        "prompt": prompt,
-        "available": suggestions["available"],
-        "taken": suggestions["taken"],
+        "local_dev": local_dev,
+        "active_creators": active,
+        "generation_count": gen_count,
+        "domain_goal": domain_goal,
+        "show_logs": show_logs,
     }
 
 
 if __name__ == "__main__":
-    result = run_test_flow("demo business", {})
-    print(result)
+    cfg = prompt_for_settings()
+    brief = input("Describe the business or project: ")
+    run_test_flow(brief, cfg)


### PR DESCRIPTION
## Summary
- allow client to set session-specific domain generation settings
- update generator to respect active creators and counts
- extend CreatorAgent with custom counts
- update API test helper to configure settings interactively
- document new settings endpoint in the README

## Testing
- `python -m py_compile api_server.py agents.py api_endpoint_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_68889061792c832ab6107a981b9512a3