### PR TITLE
Add session settings endpoint

### DIFF
--- a/api_endpoint_tester.py
+++ b/api_endpoint_tester.py
@@ -12,9 +12,14 @@ def post(path: str, payload=None):
     return resp.json()
 
 
-def run_test_flow(initial_brief: str, answer_map: dict):
+def set_settings(sid: str, settings: dict):
+    post(f"/sessions/{sid}/settings", settings)
+
+
+def run_test_flow(initial_brief: str, answer_map: dict, settings: dict):
     data = post("/sessions", {"initial_brief": initial_brief})
     sid = data["session_id"]
+    set_settings(sid, settings)
     questions = data["questions"]
 
     # Answer initial questions
@@ -37,5 +42,19 @@ def run_test_flow(initial_brief: str, answer_map: dict):
 
 
 if __name__ == "__main__":
-    result = run_test_flow("demo business", {})
+    dev = input("Use local dev mode? (y/N) ").strip().lower() == "y"
+    creators_raw = input("Creators to use [A,B,C]: ").strip() or "A,B,C"
+    creators = [c.strip() for c in creators_raw.split(",") if c.strip()]
+    gen_count = input("Generation count per creator [1]: ").strip() or "1"
+    show_logs = input("Show logs? (y/N) ").strip().lower() == "y"
+    brief = input("Describe the business or project: ")
+
+    settings_payload = {
+        "local_dev": dev,
+        "creators": creators,
+        "generation_count": int(gen_count),
+        "show_logs": show_logs,
+    }
+
+    result = run_test_flow(brief, {}, settings_payload)
     print(result)

--- a/nextjs/app/api/domain/route.ts
+++ b/nextjs/app/api/domain/route.ts
@@ -5,6 +5,8 @@ import {
   generateSuggestions,
   sendFeedback,
   getState,
+  setSettings,
+  getSettings,
 } from '@/lib/domainClient';
 
 export async function POST(req: NextRequest) {
@@ -28,6 +30,14 @@ export async function POST(req: NextRequest) {
     }
     if (body.action === 'state') {
       return NextResponse.json(await getState(body.sessionId));
+    }
+    if (body.action === 'settings') {
+      return NextResponse.json(
+        await setSettings(body.sessionId, body.payload)
+      );
+    }
+    if (body.action === 'get_settings') {
+      return NextResponse.json(await getSettings(body.sessionId));
     }
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
   } catch (err: any) {

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -47,3 +47,18 @@ export function sendFeedback(sessionId: string, payload: FeedbackPayload) {
 export function getState(sessionId: string) {
   return callApi(`/sessions/${sessionId}/state`, 'GET');
 }
+
+export interface SessionSettings {
+  local_dev: boolean;
+  creators: string[];
+  generation_count: number;
+  show_logs: boolean;
+}
+
+export function setSettings(sessionId: string, payload: SessionSettings) {
+  return callApi(`/sessions/${sessionId}/settings`, 'POST', payload);
+}
+
+export function getSettings(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/settings`, 'GET');
+}


### PR DESCRIPTION
## Summary
- allow per-session settings via new API endpoints
- support creator selection and counts in `CreatorAgent`
- update endpoint tester to request settings interactively
- expose settings helpers in Next.js client and route

## Testing
- `python -m py_compile api_server.py agents.py api_endpoint_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_688898e99830832abbf2de109beced93