### PR TITLE
Add interactive API tester with settings

### DIFF
--- a/nextjs/app/api/domain/route.ts
+++ b/nextjs/app/api/domain/route.ts
@@ -5,6 +5,8 @@ import {
   generateSuggestions,
   sendFeedback,
   getState,
+  setSettings,
+  getSettings,
 } from '@/lib/domainClient';
 
 export async function POST(req: NextRequest) {
@@ -28,6 +30,14 @@ export async function POST(req: NextRequest) {
     }
     if (body.action === 'state') {
       return NextResponse.json(await getState(body.sessionId));
+    }
+    if (body.action === 'settings') {
+      return NextResponse.json(
+        await setSettings(body.sessionId, body.payload)
+      );
+    }
+    if (body.action === 'get_settings') {
+      return NextResponse.json(await getSettings(body.sessionId));
     }
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
   } catch (err: any) {

--- a/nextjs/lib/domainClient.ts
+++ b/nextjs/lib/domainClient.ts
@@ -47,3 +47,18 @@ export function sendFeedback(sessionId: string, payload: FeedbackPayload) {
 export function getState(sessionId: string) {
   return callApi(`/sessions/${sessionId}/state`, 'GET');
 }
+
+export interface SessionSettings {
+  local_dev: boolean;
+  creators: string[];
+  generation_count: number;
+  show_logs: boolean;
+}
+
+export function setSettings(sessionId: string, payload: SessionSettings) {
+  return callApi(`/sessions/${sessionId}/settings`, 'POST', payload);
+}
+
+export function getSettings(sessionId: string) {
+  return callApi(`/sessions/${sessionId}/settings`, 'GET');
+}


### PR DESCRIPTION
## Summary
- enhance `api_endpoint_tester.py` to prompt for session settings
- start sessions with settings and run the full Q/A loop using the API

## Testing
- `python -m py_compile api_server.py agents.py api_endpoint_tester.py`


------
https://chatgpt.com/codex/tasks/task_e_688898e99830832abbf2de109beced93